### PR TITLE
Add GitHub workflow for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Build (Qt)
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: jurplel/install-qt-action@v3
+      with:
+        arch: 'gcc_64'
+        archives: 'icu qtbase qtmultimedia qtgamepad'
+    - name: Build
+      run: qmake && make


### PR DESCRIPTION
Add a CI workflow for the Qt build (Makefile and frontend code are out of date so I gave up on those)

CI runs on master-branch commits and pull requests but that can be changed.